### PR TITLE
auto add buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2] - 2023-07-13
+
+### Added
+- Aider now automatically adds all open buffers when it opens.
+- Added tips for working with buffers in Vim to the README.md file.
+
 ## [0.1] - 2023-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ The Aider Plugin for Neovim provides the `OpenAider` function, which you can cal
 - `command`: The full aider command to use - defaults to `aider`
 - `window`: The window style to use 'vsplit' (default), 'hsplit' or 'float'
 
+Note: When Aider opens, it will automatically add all open buffers to the command.
+
+## Working with Buffers in Vim
+
+If you're not familiar with buffers in Vim, here are some tips:
+
+- Use `:ls` or `:buffers` to see all open buffers.
+- Use `:b <number>` or `:buffer <number>` to switch to a specific buffer. Replace `<number>` with the buffer number.
+- Use `:bd` or `:bdelete` to close the current buffer.
+- Use `:bd <number>` or `:bdelete <number>` to close a specific buffer. Replace `<number>` with the buffer number.
+- Use `:bufdo bd` to close all buffers.
+
 Before using the `OpenAider` function, you need to require the `aider` module in your configuration file. Add the following line to your `.vimrc` or `init.vim`:
 
 ```vim

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aider Plugin for Neovim
 
-This is a simple plugin for Neovim that allows you to open a terminal window inside Neovim and run the [Aider](https://github.com/paul-gauthier/aider). I wrote it as an experiment in using Aider and it is by far the best AI coding assistant I've seen.
+This is a simple plugin for Neovim that allows you to open a terminal window inside Neovim and run [Aider](https://github.com/paul-gauthier/aider). I wrote it as an experiment in using Aider which is by far the best AI coding assistant I've seen, and now just a few keystrokes away in vim.
 
 ## Installation
 

--- a/lua/aider.lua
+++ b/lua/aider.lua
@@ -27,6 +27,13 @@ function M.OpenAider(command, window_type)
     command = command or 'aider'
     window_type = window_type or 'vsplit'
     open_window(window_type)
+    local buffers = vim.api.nvim_list_bufs()
+    for _, buf in ipairs(buffers) do
+        if vim.api.nvim_buf_is_loaded(buf) then
+            local bufname = vim.api.nvim_buf_get_name(buf)
+            command = command .. " " .. bufname
+        end
+    end
     vim.fn.termopen(command, {on_exit = 'OnExit'})
 end
 

--- a/lua/aider.lua
+++ b/lua/aider.lua
@@ -31,7 +31,9 @@ function M.OpenAider(command, window_type)
     for _, buf in ipairs(buffers) do
         if vim.api.nvim_buf_is_loaded(buf) then
             local bufname = vim.api.nvim_buf_get_name(buf)
-            command = command .. " " .. bufname
+            if not bufname:match('^term:') then
+                command = command .. " " .. bufname
+            end
         end
     end
     vim.fn.termopen(command, {on_exit = 'OnExit'})


### PR DESCRIPTION
- aider: Append the name of each loaded buffer to the `aider` command when opening aider.
- aider: Prevented buffers starting with 'term:' from being added to the Aider command.
- aider: Add note to README.md about automatically adding open buffers when Aider opens.
- aider: Added release entry for version 2.0 with new features and improvements.
