### PR TITLE
Customizable ignore list of buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,15 @@ The Aider Plugin for Neovim provides a `setup` function that you can use to conf
 
 - `auto_manage_context`: A boolean value that determines whether the plugin should automatically manage the context. If set to `true`, the plugin will automatically add and remove buffers from the context as they are opened and closed. Defaults to `true`.
 - `default_bindings`: A boolean value that determines whether the plugin should use the default keybindings. If set to `true`, the plugin will require the keybindings file and set the default keybindings. Defaults to `true`.
+- `ignore_buffers`: A list of matching patterns for buffer names that will be ignored. Defaults to `{'^term:', 'NeogitConsole', 'NvimTree_', 'neo-tree filesystem'}`.
 
 Here is an example of how to use the `setup` function:
 
 ```lua
 require('aider').setup({
   auto_manage_context = false,
-  default_bindings = false
+  default_bindings = false,
+  ignore_buffers = {},
 })
 ```
 

--- a/doc/aider.txt
+++ b/doc/aider.txt
@@ -19,13 +19,15 @@ The plugin provides a `setup` function that you can use to configure the plugin.
 
 - `auto_manage_context`: A boolean value that determines whether the plugin should automatically manage the context. If set to `true`, the plugin will automatically add and remove buffers from the context as they are opened and closed. Defaults to `true`.
 - `default_bindings`: A boolean value that determines whether the plugin should use the default keybindings. If set to `true`, the plugin will require the keybindings file and set the default keybindings. Defaults to `true`.
+- `ignore_buffers`: A list of matching patterns for buffer names that will be ignored. Defaults to `{'^term:', 'NeogitConsole', 'NvimTree_', 'neo-tree filesystem'}`.
 
 Here is an example of how to use the `setup` function:
 
 ```lua
 require('aider').setup({
   auto_manage_context = false,
-  default_bindings = false
+  default_bindings = false,
+  ignore_buffers = {},
 })
 ```
 

--- a/lua/aider.lua
+++ b/lua/aider.lua
@@ -28,7 +28,7 @@ function M.AiderOpen(args, window_type)
   else
     command = 'aider ' .. (args or '')
     helpers.open_window(window_type)
-    command = helpers.add_buffers_to_command(command)
+    command = helpers.add_buffers_to_command(command, M.config.ignore_buffers)
     M.aider_job_id = vim.fn.termopen(command, {on_exit = OnExit})
     M.aider_buf = vim.api.nvim_get_current_buf()
   end
@@ -71,6 +71,7 @@ function M.setup(config)
   M.config = config or {}
   M.config.auto_manage_context = M.config.auto_manage_context or true
   M.config.default_bindings = M.config.default_bindings or true
+  M.config.ignore_buffers = M.config.ignore_buffers or {'^term:', 'NeogitConsole', 'NvimTree_', 'neo-tree filesystem'}
 
   vim.g.aider_buffer_sync = M.config.auto_manage_context
 

--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -48,15 +48,19 @@ local function showProcessingCue()
   set_idle_status(false)
 end
 
-local function add_buffers_to_command(command)
+local function add_buffers_to_command(command, ignore_buffers)
   local buffers = vim.api.nvim_list_bufs()
   for _, buf in ipairs(buffers) do
     if vim.api.nvim_buf_is_loaded(buf) then
       local bufname = vim.api.nvim_buf_get_name(buf)
-      if not bufname:match('^term:') and not bufname:match('NeogitConsole') then
-        command = command .. " " .. bufname
+      for _, ignore_buf in ipairs(ignore_buffers or {}) do
+        if bufname:match(ignore_buf) then
+          goto continue
+        end
       end
+      command = command .. " " .. bufname
     end
+    ::continue::
   end
   return command
 end


### PR DESCRIPTION
Thank you for your excellent work!

The Aider creates unnecessary plugin files in the project directory whenever it loads.
As a result, Nvimtree does not function properly.
It seems that it would be beneficial to allow users to create their own matching list.